### PR TITLE
Skip remi repo on Amazon linux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -129,13 +129,14 @@
       create: yes
 
   - name: Install remi repo.
-    when: ansible_os_family == 'RedHat'
+    when: ansible_os_family == 'RedHat' and ansible_distribution != "Amazon"
     yum:
       name: "{{ remi_repo_url }}"
       state: present
 
   - name: Import remi GPG key.
-    when: ansible_os_family == 'RedHat'
+    when: ansible_os_family == 'RedHat' and ansible_distribution != "Amazon"
     rpm_key:
       key: "{{ remi_repo_gpg_key_url }}"
       state: present
+


### PR DESCRIPTION
We are having trouble installing on Amazonlinux. This is an attempt to fix it.